### PR TITLE
Change default to SDSS III site (original CasJobs is closing down)

### DIFF
--- a/casjobs.py
+++ b/casjobs.py
@@ -24,11 +24,13 @@ class CasJobs(object):
       provided by the `CASJOBS_PW` environment variable.
     * `base_url` (str): The base URL that you'd like to use depending on the
       service that you're accessing. This module has only really been tested
-      with `http://casjobs.sdss.org/CasJobs/services/jobs.asmx`.
+      with ``http://casjobs.sdss.org/CasJobs/services/jobs.asmx`` (the original
+      CasJobs for SDSS I and II, closed Jul 31, 2014), as well as the default
+      (maintained by SDSS III).
 
     """
     def __init__(self, userid=None, password=None,
-            base_url="http://casjobs.sdss.org/CasJobs/services/jobs.asmx"):
+            base_url="http://skyserver.sdss3.org/casjobs/services/jobs.asmx"):
         self.userid = userid
         if userid is None:
             self.userid = int(os.environ["CASJOBS_WSID"])


### PR DESCRIPTION
If you go to http://skyserver.sdss.org/casjobs/, you can see the following comment:

> this site will be retired On July 31, 2014 to be replaced by the SDSS-III CasJobs site 

with that in mind, this PR just changes the default `base_url from the original SDSS I/II CasJobs to the SDSS III CasJobs (as well as mentioning a bit more in the docstring about it)
