### PR TITLE
Make code Python 2.7 compatible again

### DIFF
--- a/casjobs.py
+++ b/casjobs.py
@@ -8,11 +8,21 @@ __all__ = ["CasJobs"]
 import time
 import os
 import logging
-import html
 import re
 from xml.dom import minidom
-
 import requests
+
+try:
+    from html import unescape
+except ImportError:
+    # Python 2.7
+    import htmllib
+    def unescape(s):
+        p = htmllib.HTMLParser(None)
+        p.save_bgn()
+        p.feed(s)
+        return p.save_end()
+
 
 class CasJobs(object):
     """
@@ -119,7 +129,7 @@ class CasJobs(object):
             msg = mm.group('msg')
         else:
             msg = '\n'.join(text.split('\n')[:maxlines])
-        return html.unescape(msg)
+        return unescape(msg)
 
     def _parse_single(self, text, tagname):
         """


### PR DESCRIPTION
The html.unescape function is not available in Python 2.7.  In that case it is replaced with another function (which is not available in Python 3, sigh).

This fixes the [problem reported](https://github.com/dfm/casjobs/pull/9#issuecomment-661710869) by @MikeeRead.  While Python 2.7 compatibility is being dropped many places, this is a simple change to retain it in this very stable module.