### PR TITLE
Fix a bug on Windows

### DIFF
--- a/casjobs.py
+++ b/casjobs.py
@@ -88,7 +88,7 @@ class CasJobs(object):
         params["wsid"] = params.get("wsid", self.userid)
         params["pw"]   = params.get("pw", self.password)
 
-        path = os.path.join(self.base_url, job_type)
+        path = self.base_url + '/' + job_type
         if self.request_type == 'GET':
             r = requests.get(path, params=params)
         elif self.request_type == 'POST':


### PR DESCRIPTION
Using os.path.join to add the job_type component to the URL is
incorrect on Windows.  The URL path separator is '/' on all systems, but
the Windows filesystem separator is '\\'.  The fix is just to explicitly
join the path using '/', which works on all systems.